### PR TITLE
Add the ability to scrape comments from Subreddits

### DIFF
--- a/Scraper.py
+++ b/Scraper.py
@@ -44,7 +44,7 @@ os.chdir(directory_name)
 r = praw.Reddit('Comment Scraper 1.0 by u/_Daimon_ see '
     'https://praw.readthedocs.org/en/latest/'
     'pages/comment_parsing.html')
-#r.login('USERNAME', 'PASSWORD', disable_warning=True) # change these to your login details
+r.login('USERNAME', 'PASSWORD', disable_warning=True) # change these to your login details
 
 
 


### PR DESCRIPTION
This adds the ability to scrape comments from a subreddit (/r/all/comments for example).

Don't know if your wanting pull requests but I added a couple of changes which I found useful. These changes allow the unique id to be passed to the script (python Scraper.py 41e5y), which has the same behaviour as before. 
Or/and if a subreddit is passed as so;
python Scraper.py /r/all
 The comments from there will be grabbed instead. The script defaults to 1000 comments, but this can be changed by passing the limit you would like along with the subreddit (Scraper.py /r/all 100) and writes this to the CSV file,
Thanks, hope you at least find this useful.